### PR TITLE
feat: add AMI_PASSTHROUGH env var for read-only tool opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Crush > Goose > Zed
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `AMI_DEBUG` | Enable debug output | `false` |
+| `AMI_PASSTHROUGH` | Skip all AI detection, return "none" | `false` |
 
 ## Installation
 

--- a/am-i-ai.sh
+++ b/am-i-ai.sh
@@ -443,6 +443,14 @@ ami_is_ai() {
 # Get all detected AI tools (not just the highest priority one)
 # Returns space-separated list or empty string
 ami_detect_all() {
+    # Allow callers to opt out of AI detection (e.g., read-only tools)
+    # Set AMI_PASSTHROUGH=true to force empty result
+    if [[ "${AMI_PASSTHROUGH:-}" == "true" ]]; then
+        _ami_debug "AMI_PASSTHROUGH is set, returning empty"
+        echo ""
+        return 0
+    fi
+
     local env_detected
     env_detected=$(ami_check_env)
 


### PR DESCRIPTION
## What

Adds `AMI_PASSTHROUGH=true` environment variable support to `ami_detect()`.

When set, `ami_detect()` returns `"none"` immediately, skipping all detection logic. The convenience function `ami_is_ai()` correspondingly returns false (exit code 1).

## Why

Read-only tools (like `gh-monday`) that run under AI agents shouldn't trigger AI-aligned behavior. These tools merely fetch data — they don't make decisions or generate content on behalf of the AI. Without an opt-out mechanism, any tool sourcing `am-i-ai` inside an AI agent session would incorrectly report AI detection, causing downstream behavior changes that aren't appropriate for passthrough/read-only use cases.

This provides a clean, library-level escape hatch.

## How

- Early-return guard at the top of `ami_detect()`: when `AMI_PASSTHROUGH=true`, returns `"none"` immediately
- Uses `${AMI_PASSTHROUGH:-}` for safe unset-variable handling
- Emits a debug message via `_ami_debug` for traceability
- Added a doc comment on `ami_is_ai()` noting the passthrough behavior

## Usage

```bash
export AMI_PASSTHROUGH=true
# Any tool that sources am-i-ai will now report no AI detected
```

Typical use in a wrapper script:

```bash
AMI_PASSTHROUGH=true some-read-only-tool --query "..."
```