### PR TITLE
Add Grok Build (xAI) detection and attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ ami_detect_all
 | [Cline](https://cline.bot) | Process + env | `CLINE_TASK_ID` |
 | [Roo Code](https://roocode.dev) | Process + env | `ROO_CODE_TASK_ID` |
 | [Windsurf](https://codeium.com/windsurf) | Process + env | `WINDSURF_SESSION` |
+| [Grok Build](https://x.ai) | Process + env | `GROK_CODE_XAI_API_KEY`, `GROK_MODEL` (primary: process tree `grok`) |
 
 ## Detection Methods
 
@@ -108,7 +109,7 @@ Zed presents a unique challenge because it sets environment variables for all te
 When multiple AI tools are detected (e.g., Claude running inside Cursor), the more specific tool takes precedence:
 
 ```
-Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode >
+Amp > Codex > Aider > Grok > Claude > Gemini > Qwen > Droid > OpenCode >
 Cursor > Copilot > Kimi > OpenHands > Cline > Roo > Windsurf >
 Crush > Goose > Zed
 ```

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ ami_detect_all
 | [Cline](https://cline.bot) | Process + env | `CLINE_TASK_ID` |
 | [Roo Code](https://roocode.dev) | Process + env | `ROO_CODE_TASK_ID` |
 | [Windsurf](https://codeium.com/windsurf) | Process + env | `WINDSURF_SESSION` |
-| [Grok Build](https://x.ai) | Process + env | `GROK_CODE_XAI_API_KEY`, `GROK_MODEL` (primary: process tree `grok`) |
+| [Grok Build](https://x.ai/cli) | Process + env | `GROK_CODE_XAI_API_KEY`, `GROK_MODEL` (primary: process tree `grok`) |
 
 ## Detection Methods
 

--- a/am-i-ai.sh
+++ b/am-i-ai.sh
@@ -63,6 +63,15 @@ ami_check_env() {
         _ami_debug "Detected Claude via environment variable"
     fi
 
+    # Grok Build detection (xAI)
+    # Primary detection via process tree (the 'grok' binary or 'grok-macos-*' is the TUI/agent parent)
+    # GROK_CODE_XAI_API_KEY for API key auth in headless/agent mode (not always exported to child processes)
+    # GROK_MODEL=grok-build or GROK_BUILD may be set in some contexts
+    if [ -n "$GROK_CODE_XAI_API_KEY" ] || [ -n "$GROK_BUILD" ] || [ "$GROK_MODEL" = "grok-build" ]; then
+        detected="$detected grok"
+        _ami_debug "Detected Grok Build via environment variable"
+    fi
+
     # Gemini detection
     if [ -n "$GEMINI_CLI" ]; then
         detected="$detected gemini"
@@ -287,6 +296,11 @@ ami_check_ps_tree() {
             detected="$detected goose"
             _ami_debug "Detected Goose in process tree at depth $depth"
         fi
+        # Grok Build detection - look for grok in process command (binary is grok or grok-macos-*)
+        if ami_process_contains "$current_pid" "grok"; then
+            detected="$detected grok"
+            _ami_debug "Detected Grok Build in process tree at depth $depth"
+        fi
         # Auggie detection - look for auggie in process command
         if ami_process_contains "$current_pid" "auggie"; then
             detected="$detected auggie"
@@ -366,7 +380,7 @@ ami_detect() {
     _ami_debug "Process tree detected: '$ps_detected'"
     _ami_debug "Combined detected: '$all_detected'"
 
-    # Priority order: Amp > Codex > Aider > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Copilot > Kimi > OpenHands > Cline > Roo > Windsurf > Crush > Goose > Auggie > Zed
+    # Priority order: Amp > Codex > Aider > Grok > Claude > Gemini > Qwen > Droid > OpenCode > Cursor > Copilot > Kimi > OpenHands > Cline > Roo > Windsurf > Crush > Goose > Auggie > Zed
     # Zed is last because it often hosts other AI tools
     # More specific AI tools take precedence over IDE-level tools
     if [[ "$all_detected" =~ "amp" ]]; then
@@ -378,6 +392,9 @@ ami_detect() {
     elif [[ "$all_detected" =~ "aider" ]]; then
         _ami_debug "Final result: aider"
         echo "aider"
+    elif [[ "$all_detected" =~ "grok" ]]; then
+        _ami_debug "Final result: grok"
+        echo "grok"
     elif [[ "$all_detected" =~ "claude" ]]; then
         _ami_debug "Final result: claude"
         echo "claude"
@@ -485,6 +502,7 @@ ami_get_email() {
         "openhands") echo "openhands@all-hands.dev" ;;
         "crush")    echo "crush@charm.land" ;;
         "goose")    echo "goose@opensource.block.xyz" ;;
+        "grok")     echo "grok@x.ai" ;;
         "auggie")   echo "noreply@augmentcode.com" ;;
         "cline")    echo "cline@cline.bot" ;;
         "roo")      echo "roo@roocode.dev" ;;
@@ -514,6 +532,7 @@ ami_get_name() {
         "openhands") echo "OpenHands" ;;
         "crush")    echo "Crush" ;;
         "goose")    echo "Goose User" ;;
+        "grok")     echo "Grok Build" ;;
         "auggie")   echo "Augment Code" ;;
         "cline")    echo "Cline" ;;
         "roo")      echo "Roo Code" ;;


### PR DESCRIPTION
## Summary

Adds first-class support for **Grok Build** (xAI's terminal AI coding agent / TUI) to the shared `am-i-ai` detection library.

This is the canonical change. Once merged, the `propagate-updates.yml` workflow will automatically open PRs to update the inlined bundles in `ai-aligned-git` and `ai-aligned-gh`.

## Detection

- **Primary**: Process tree walk — the parent process of any command is the `grok` binary (`~/.local/bin/grok` → `grok-macos-aarch64` etc.). Matches the same pattern used for Claude, Aider, Goose, Crush, etc.
- **Secondary**: Environment variables for headless / ACP / agent mode (`GROK_CODE_XAI_API_KEY`, `GROK_MODEL=grok-build`).

Priority placed right after Aider (Grok Build is a full autonomous coding agent TUI, comparable to Claude Code).

## Attribution

When Grok Build runs `git commit`:
- Author becomes `Grok Build <grok@x.ai>`
- Human developer still gets the `Signed-off-by:` trailer

## Dogfooding (the commit that adds Grok support *was made by Grok*)

This PR branch was created and committed **while running inside Grok Build**, using a locally patched `ai-aligned-git` wrapper (`~/.local/bin/git` built from the modified `executable_git`).

The resulting commit:
- Author: **Grok Build <grok@x.ai>**
- Contains the human `Signed-off-by: Lars Trieloff <lars@trieloff.net>` trailer
- The wrapper correctly enforced AI safety rules and emitted the gentle `--prompt` reminder

```
$ git log -1 --pretty=fuller
Author:     Grok Build <grok@x.ai>
...
    Signed-off-by: Lars Trieloff <lars@trieloff.net>
```

This is the intended behavior the entire AI Ecoverse toolset is designed to produce.

## Files changed

- `am-i-ai.sh`: env check, process-tree check, priority ordering, `ami_get_name`/`ami_get_email`
- `README.md`: supported tools table + priority documentation

## Test plan

- [x] Verified live inside Grok Build TUI (process tree detection + attribution)
- [x] `ami_detect` returns `grok`
- [x] Name/email functions return correct values
- [x] Commit through patched wrapper produced correct author + trailer
- [ ] After merge, confirm propagate workflow updates the dependent repos