### PR TITLE
Detect Codex Desktop environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ ami_detect_all
 |------|------------------|---------------------|
 | [Claude Code](https://claude.ai/claude-code) | Process + env | `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT` |
 | [Gemini](https://codeassist.google/) | Process + env | `GEMINI_CLI` |
-| [Codex CLI](https://openai.com) | Process + env | `CODEX_CLI`, `CODEX_SANDBOX` |
+| [Codex](https://openai.com/codex/) | Process + env | `CODEX_CLI`, `CODEX_SANDBOX`, `CODEX_SHELL`, `CODEX_THREAD_ID` |
 | [Cursor](https://cursor.com) | Process + env | `CURSOR_AGENT` |
 | [Aider](https://aider.chat) | Process + env | `OR_APP_NAME=Aider` |
 | [Amp](https://ampcode.com) | Process + env | `AGENT=amp`, `AMP_HOME` |

--- a/am-i-ai.sh
+++ b/am-i-ai.sh
@@ -104,9 +104,11 @@ ami_check_env() {
         _ami_debug "Detected OpenCode via environment variable"
     fi
 
-    # Codex CLI detection
-    # Detect via CODEX_CLI env var or CODEX_SANDBOX (set in sandboxed ACP sessions)
-    if [ -n "$CODEX_CLI" ] || [ -n "$CODEX_SANDBOX" ]; then
+    # Codex detection
+    # CLI sets CODEX_CLI, sandboxed ACP sessions set CODEX_SANDBOX,
+    # and Codex Desktop shells expose CODEX_SHELL/CODEX_THREAD_ID.
+    if [ -n "$CODEX_CLI" ] || [ -n "$CODEX_SANDBOX" ] || \
+       [ -n "$CODEX_SHELL" ] || [ -n "$CODEX_THREAD_ID" ]; then
         detected="$detected codex"
         _ami_debug "Detected Codex via environment variable"
     fi
@@ -247,7 +249,7 @@ ami_check_ps_tree() {
             detected="$detected gemini"
             _ami_debug "Detected Gemini in process tree at depth $depth"
         fi
-        # Detect Codex CLI by process name
+        # Detect Codex CLI/Desktop by process name
         if ami_process_contains "$current_pid" "codex"; then
             detected="$detected codex"
             _ami_debug "Detected Codex in process tree at depth $depth"
@@ -546,7 +548,7 @@ ami_get_name() {
     case "$tool" in
         "claude")   echo "Claude Code" ;;
         "gemini")   echo "Gemini" ;;
-        "codex")    echo "Codex CLI" ;;
+        "codex")    echo "Codex" ;;
         "aider")    echo "Aider" ;;
         "qwen")     echo "Qwen Code" ;;
         "cursor")   echo "Cursor AI" ;;


### PR DESCRIPTION
## Summary
- detect Codex Desktop shells via CODEX_SHELL and CODEX_THREAD_ID
- broaden Codex naming/docs from Codex CLI to Codex

## Tests
- bash -n am-i-ai.sh bundle.sh install.sh
- env -i CODEX_SHELL=1 bash -c 'source ./am-i-ai.sh; ami_check_env'\n- env -i CODEX_THREAD_ID=test-thread bash -c 'source ./am-i-ai.sh; ami_check_env'\n- ./am-i-ai.sh\n- git diff --check\n\nNote: shellcheck is not installed in this local environment.