### PR TITLE
feat: detect Intent by Augment via AUGMENT_AGENT env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ ami_detect_all
 | [OpenHands](https://openhands.ai) | Process + env | `OR_APP_NAME=OpenHands`, `OR_SITE_URL` |
 | [Crush](https://charm.sh/tools/crush/) | Process only | (detected via process tree) |
 | [Goose](https://github.com/block/goose) | Process + env | `GOOSE_TERMINAL` |
+| [Auggie](https://www.augmentcode.com) | Process + env | `AUGMENT_API_TOKEN`, `AUGMENT_AGENT` |
 | [Cline](https://cline.bot) | Process + env | `CLINE_TASK_ID` |
 | [Roo Code](https://roocode.dev) | Process + env | `ROO_CODE_TASK_ID` |
 | [Windsurf](https://codeium.com/windsurf) | Process + env | `WINDSURF_SESSION` |

--- a/am-i-ai.sh
+++ b/am-i-ai.sh
@@ -188,7 +188,8 @@ ami_check_env() {
     fi
 
     # Auggie detection (Augment Code)
-    if [ -n "$AUGMENT_API_TOKEN" ]; then
+    # Intent by Augment / ACP mode sets AUGMENT_AGENT=1 without AUGMENT_API_TOKEN.
+    if [ -n "$AUGMENT_API_TOKEN" ] || [ -n "$AUGMENT_AGENT" ]; then
         detected="$detected auggie"
         _ami_debug "Detected Auggie via environment variable"
     fi


### PR DESCRIPTION
## Summary

Closes a Phase-1 detection gap for Intent by Augment.

Intent runs `auggie` as an ACP agent and sets `AUGMENT_AGENT=1` in the
agent's environment, but it does **not** set `AUGMENT_API_TOKEN`. As a
result, `ami_check_env` previously missed Intent entirely, and detection
fell through to the process-tree fallback — which is fragile (binary
renames, wrapper scripts, deep trees, sandboxed children).

This change makes `ami_check_env` recognize Intent's `AUGMENT_AGENT`
env var directly.

## Changes

- `am-i-ai.sh` — `ami_check_env` Auggie block now matches either
  `AUGMENT_API_TOKEN` or `AUGMENT_AGENT`. Comment updated to call out
  the Intent / ACP-mode signal.
- `README.md` — added the missing **Auggie** row to the Supported AI
  Tools table, listing both env vars.

No change to `AMI_VERSION` (handled by the release workflow).

## Verification

```bash
# Sourced so the harness shell's own env doesn't taint results:
$ bash -c 'source ./am-i-ai.sh; AUGMENT_AGENT=1 ami_check_env'
 auggie
$ bash -c 'source ./am-i-ai.sh; unset AUGMENT_AGENT AUGMENT_API_TOKEN; ami_check_env'
(empty)
$ bash -c 'source ./am-i-ai.sh; CLAUDECODE=1 ami_check_env'
 claude

$ shellcheck am-i-ai.sh
(clean)
```
